### PR TITLE
Specify node version to avoid security flaw

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": "6.11.1"
-  }
+  },
   "author": "Mitchell Urgero",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,15 @@
   "name": "pandjs",
   "version": "1.0.0",
   "description": "Pandora Web Client For NodeJS",
+  
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "npm install && node index.js"
   },
+  "engines": {
+    "node": "6.11.1"
+  }
   "author": "Mitchell Urgero",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
The node.js team announced that a Denial of Service (DoS) Constant Hashtable Seeds vulnerability in Node.js versions 4.x through 8.x has been patched in the following versions:

4.8.4
6.11.1
7.10.1
8.1.4

This PR specifies in packages.json to use 6.11.1 to ensure there is no vulnerability.